### PR TITLE
Run tests on CI against different versions of Grafana

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ] # , macos-latest, windows-latest ]
         python-version: [ "3.6", "3.7", "3.8", "3.9" ]
-        grafana-version: [ "8.x.x" ]
+        grafana-version: [ "6.7.6", "7.5.10", "8.1.5" ]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip
@@ -29,8 +29,9 @@ jobs:
         #  path: ~\AppData\Local\pip\Cache
 
     env:
-      OS: ${{ matrix.os }}
-      PYTHON: ${{ matrix.python-version }}
+      OS_TYPE: ${{ matrix.os }}
+      PYTHON_VERSION: ${{ matrix.python-version }}
+      GRAFANA_VERSION: ${{ matrix.grafana-version }}
 
     name: OS ${{ matrix.os }}, Python ${{ matrix.python-version }}, Grafana ${{ matrix.grafana-version }}
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,10 +8,11 @@ in progress
 - Improve behaviour of "replace" action by clearing the cache
 - Croak when obtaining unknown report format
 - Use ANSI colors only on TTYs
-- Add software tests
+- Add software tests, with CI on GHA
 - Add monkeypatch for grafana-api package to mitigate flaw with "replace" action.
   See also https://github.com/m0nhawk/grafana_api/pull/85.
 - Bump/improve dependency versions to 3rd-party packages
+- Run tests on CI against different versions of Grafana
 
 2019-11-06 0.9.0
 ================

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,10 @@
 .. image:: https://img.shields.io/pypi/dm/grafana-wtf.svg
     :target: https://pypi.org/project/grafana-wtf/
 
+.. image:: https://img.shields.io/badge/Grafana-6.x%20--%208.x-blue.svg
+    :target: https://github.com/grafana/grafana
+    :alt: Supported Grafana versions
+
 |
 
 ###########

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,19 @@ def clean_environment():
             del os.environ[envvar]
         except KeyError:
             pass
+
+
+def update_environment():
+
+    # Set default Grafana version.
+    GRAFANA_VERSION_DEFAULT = "8.1.5"
+    if "GRAFANA_VERSION" not in os.environ:
+        os.environ["GRAFANA_VERSION"] = GRAFANA_VERSION_DEFAULT
+
+    # Report about Grafana version.
+    GRAFANA_VERSION = os.environ["GRAFANA_VERSION"]
+    sys.stderr.write(f"INFO: Running tests against Grafana version {GRAFANA_VERSION}\n")
+    sys.stderr.flush()
 
 
 @pytest.fixture(scope="session")
@@ -37,3 +51,4 @@ def docker_grafana(docker_services):
 
 
 clean_environment()
+update_environment()

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
 
   grafana:
-    image: grafana/grafana:8.1.5
+    image: grafana/grafana:${GRAFANA_VERSION}
     volumes:
       - ./grafana/datasources:/etc/grafana/provisioning/datasources/
       - ./grafana/dashboards:/etc/grafana/provisioning/dashboards/


### PR DESCRIPTION
What the title says. The patch will make the test suite on CI run against Grafana versions 6.7.6, 7.5.10 and 8.1.5.