### PR TITLE
Add feature to display datasource breakdown

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,9 +5,14 @@ grafana-wtf changelog
 
 in progress
 ===========
-- Upgrade to ``colored==1.4.3``
+
+2021-12-10 0.11.0
+=================
+- Upgrade to ``colored==1.4.3``. Thanks, @dslackw!
 - Tests: Use ``.env`` file for propagating environment variables to Docker Compose
 - CI/GHA test matrix: Use Grafana 7.5.11 and 8.3.1 and add Python 3.10
+- Add feature to display datasource breakdown, specifically for finding unused
+  data sources. Thanks, @chenlujjj!
 
 2021-10-01 0.10.0
 =================

--- a/grafana_wtf/model.py
+++ b/grafana_wtf/model.py
@@ -1,0 +1,31 @@
+import dataclasses
+from typing import List
+
+from munch import Munch
+from collections import OrderedDict
+from urllib.parse import urljoin
+
+
+@dataclasses.dataclass
+class DatasourceBreakdownItem:
+    datasource: Munch
+    used_in: List[Munch]
+    grafana_url: str
+
+    def format_compact(self):
+        dsshort = OrderedDict(
+            name=self.datasource.name,
+            type=self.datasource.type,
+            url=self.datasource.url,
+        )
+        item = OrderedDict(datasource=dsshort)
+        for dashboard in self.used_in:
+            item.setdefault("dashboards", [])
+            dbshort = OrderedDict(
+                title=dashboard.dashboard.title,
+                uid=dashboard.dashboard.uid,
+                path=dashboard.meta.url,
+                url=urljoin(self.grafana_url, dashboard.meta.url),
+            )
+            item["dashboards"].append(dbshort)
+        return item

--- a/grafana_wtf/util.py
+++ b/grafana_wtf/util.py
@@ -4,6 +4,9 @@
 import sys
 import json
 import logging
+from collections import OrderedDict
+
+import yaml
 from munch import munchify
 from jsonpath_rw import parse
 from pygments import highlight
@@ -106,3 +109,22 @@ class JsonPathFinder:
 def prettify_json(data):
     json_str = json.dumps(data, indent=4)
     return highlight(json_str, JsonLexer(), TerminalFormatter())
+
+
+def yaml_dump(data, stream=None, Dumper=yaml.SafeDumper, **kwds):
+    """
+    https://stackoverflow.com/questions/5121931/in-python-how-can-you-load-yaml-mappings-as-ordereddicts
+    """
+
+    kwds["default_flow_style"] = False
+
+    class OrderedDumper(Dumper):
+        pass
+
+    def _dict_representer(dumper, data):
+        return dumper.represent_mapping(
+            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+            data.items())
+
+    OrderedDumper.add_representer(OrderedDict, _dict_representer)
+    return yaml.dump(data, stream, OrderedDumper, **kwds)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ requires = [
 
     # Core
     'six',
+    'dataclasses; python_version<"3.7"',
     'docopt>=0.6.2,<0.7',
     'munch>=2.5.0,<3',
     'tqdm>=4.37.0,<5',
@@ -25,6 +26,7 @@ requires = [
     'tabulate>=0.8.5,<0.9',
     'colored>=1.4.3,<2',
     'Pygments>=2.7.4,<3',
+    'PyYAML>=5,<6',
 
 ]
 


### PR DESCRIPTION
Hi there,

this feature can specifically be used to find unused data sources. The topic has been brought up by @chenlujjj at [1], thanks!

#### Synopsis
```shell
# Set URL to Grafana.
export GRAFANA_URL=https://grafana.example.org/

# Display names of unused datasources as a flat list.
grafana-wtf datasource-breakdown --format=json | jq -r '.unused[].datasource.name'
```

With kind regards,
Andreas.

[1] https://community.grafana.com/t/how-to-find-out-unused-datasources/56920
