### PR TITLE
Add subcommand `info`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ in progress
 - CI/GHA test matrix: Use Grafana 7.5.12 and 8.3.2
 - Add subcommand ``info``, to display Grafana version and statistics about all entities
 - For ``info`` subcommand, add Grafana ``url`` attribute
+- Add example how to print the Grafana version using the ``info`` subcommand
 
 2021-12-10 0.11.1
 =================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ in progress
 - Add subcommand ``info``, to display Grafana version and statistics about all entities
 - For ``info`` subcommand, add Grafana ``url`` attribute
 - Add example how to print the Grafana version using the ``info`` subcommand
+- Add more information about dashboard entities to ``info`` subcommand
 
 2021-12-10 0.11.1
 =================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ in progress
 - Add subcommand ``explore dashboards``, e.g. for discovering dashboards using
   missing data sources.
 - CI/GHA test matrix: Use Grafana 7.5.12 and 8.3.2
+- Add subcommand ``info``, to display Grafana version and statistics about all entities
 
 2021-12-10 0.11.1
 =================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ in progress
   missing data sources.
 - CI/GHA test matrix: Use Grafana 7.5.12 and 8.3.2
 - Add subcommand ``info``, to display Grafana version and statistics about all entities
+- For ``info`` subcommand, add Grafana ``url`` attribute
 
 2021-12-10 0.11.1
 =================

--- a/README.rst
+++ b/README.rst
@@ -165,8 +165,11 @@ Display common information and statistics
 =========================================
 ::
 
-    grafana-wtf info
+    # Display a bunch of meta information and statistics.
+    grafana-wtf info --format=yaml
 
+    # Display Grafana version.
+    grafana-wtf info --format=json | jq -r '.grafana.version'
 
 
 ********

--- a/README.rst
+++ b/README.rst
@@ -161,6 +161,14 @@ How to find dashboards which use non-existing data sources?
     grafana-wtf explore dashboards --format=json | jq '.[] | select( .datasources_missing ) | .dashboard + {ds_missing: .datasources_missing[] | [.name]}'
 
 
+Display common information and statistics
+=========================================
+::
+
+    grafana-wtf info
+
+
+
 ********
 Examples
 ********

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -6,9 +6,6 @@ grafana-wtf backlog
 ******
 Prio 1
 ******
-- [o] Add subcommand ``explore dashboards``
-- [o] Number of dashboards, users, and playlists
-      -- via: https://grafana.com/docs/grafana/latest/administration/view-server/internal-metrics/
 - [o] Dockerize
 - [o] Statistics reports for data sources and panels: https://github.com/panodata/grafana-wtf/issues/18
 - [o] Finding invalid data sources: https://github.com/panodata/grafana-wtf/issues/19
@@ -17,6 +14,9 @@ Prio 1
 ********
 Prio 1.5
 ********
+- [o] Check if we can collect metrics from Grafana
+      - https://grafana.com/docs/grafana/latest/administration/view-server/internal-metrics/
+      - https://grafana.com/docs/grafana/latest/developers/plugins/backend/#collect-metrics
 - [o] Add test fixture which completely resets everything in Grafana before running the test harness.
       Move to a different port than 3000 then!
 - [o] Improve output format handling and error cases
@@ -50,3 +50,7 @@ Done
 - [x] Document "replace" feature in README
 - [x] AttributeError: https://github.com/panodata/grafana-wtf/issues/17
 - [/] Repair ``log`` subcommand
+- [x] Add subcommand ``explore dashboards``
+- [x] Add subcommand ``info``
+    - Display Grafana version: https://grafana.com/docs/grafana/latest/http_api/other/#health-api
+    - Display number of dashboards, folders, users, and playlists

--- a/grafana_wtf/commands.py
+++ b/grafana_wtf/commands.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 from docopt import docopt, DocoptExit
 
 from grafana_wtf import __appname__, __version__
-from grafana_wtf.core import GrafanaSearch
+from grafana_wtf.core import GrafanaWtf
 from grafana_wtf.report import WtfReport
 from grafana_wtf.tabular_report import TabularReport
 from grafana_wtf.util import normalize_options, setup_logging, configure_http_logging, read_list, yaml_dump
@@ -24,11 +24,12 @@ log = logging.getLogger(__name__)
 def run():
     """
     Usage:
+      grafana-wtf [options] info
+      grafana-wtf [options] explore datasources
+      grafana-wtf [options] explore dashboards
       grafana-wtf [options] find [<search-expression>]
       grafana-wtf [options] replace <search-expression> <replacement>
       grafana-wtf [options] log [<dashboard_uid>] [--number=<count>]
-      grafana-wtf [options] explore datasources
-      grafana-wtf [options] explore dashboards
       grafana-wtf --version
       grafana-wtf (-h | --help)
 
@@ -145,7 +146,7 @@ def run():
     if grafana_url is None:
         raise DocoptExit('No Grafana URL given. Please use "--grafana-url" option or environment variable "GRAFANA_URL".')
 
-    engine = GrafanaSearch(grafana_url, grafana_token)
+    engine = GrafanaWtf(grafana_url, grafana_token)
     engine.enable_cache(expire_after=cache_ttl, drop_cache=options['drop-cache'])
     engine.enable_concurrency(int(options['concurrency']))
     engine.setup()
@@ -164,7 +165,7 @@ def run():
 
         else:
             # Scan everything.
-            engine.scan()
+            engine.scan_common()
 
         result = engine.search(options.search_expression or None)
 
@@ -217,6 +218,10 @@ def run():
     if options.explore and options.dashboards:
         results = engine.explore_dashboards()
         output_results(output_format, results)
+
+    if options.info:
+        response = engine.info()
+        output_results(output_format, response)
 
 
 def output_results(output_format: str, results: List):

--- a/grafana_wtf/core.py
+++ b/grafana_wtf/core.py
@@ -249,6 +249,7 @@ class GrafanaWtf(GrafanaEngine):
         response = OrderedDict(
             grafana=OrderedDict(
                 version=health.get("version"),
+                url=self.grafana_url,
             ),
             statistics=OrderedDict(),
             summary=OrderedDict(),

--- a/grafana_wtf/model.py
+++ b/grafana_wtf/model.py
@@ -22,6 +22,24 @@ class GrafanaDataModel:
 
 
 @dataclasses.dataclass
+class DashboardDetails:
+
+    dashboard: Dict
+
+    @property
+    def panels(self) -> List:
+        return self.dashboard.dashboard.get("panels", [])
+
+    @property
+    def annotations(self) -> List:
+        return self.dashboard.dashboard.get("annotations", {}).get("list", [])
+
+    @property
+    def templating(self) -> List:
+        return self.dashboard.dashboard.get("templating", {}).get("list", [])
+
+
+@dataclasses.dataclass
 class DatasourceExplorationItem:
     datasource: Munch
     used_in: List[Munch]

--- a/grafana_wtf/model.py
+++ b/grafana_wtf/model.py
@@ -1,9 +1,24 @@
 import dataclasses
-from typing import List
+from typing import List, Optional, Dict
 
 from munch import Munch
 from collections import OrderedDict
 from urllib.parse import urljoin
+
+
+@dataclasses.dataclass
+class GrafanaDataModel:
+    admin_stats: Optional[Dict] = dataclasses.field(default_factory=dict)
+    dashboards: Optional[List[Munch]] = dataclasses.field(default_factory=list)
+    dashboard_list: Optional[List[Munch]] = dataclasses.field(default_factory=list)
+    datasources: Optional[List[Munch]] = dataclasses.field(default_factory=list)
+    folders: Optional[List[Munch]] = dataclasses.field(default_factory=list)
+    organizations: Optional[List[Munch]] = dataclasses.field(default_factory=list)
+    users: Optional[List[Munch]] = dataclasses.field(default_factory=list)
+    teams: Optional[List[Munch]] = dataclasses.field(default_factory=list)
+    annotations: Optional[List[Munch]] = dataclasses.field(default_factory=list)
+    snapshots: Optional[List[Munch]] = dataclasses.field(default_factory=list)
+    notifications: Optional[List[Munch]] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from grafana_api.grafana_api import GrafanaClientError
 
-from grafana_wtf.core import GrafanaSearch
+from grafana_wtf.core import GrafanaWtf
 
 
 def clean_environment():
@@ -44,7 +44,7 @@ def docker_grafana(docker_services):
 def create_datasource(docker_grafana):
     # https://docs.pytest.org/en/4.6.x/fixture.html#factories-as-fixtures
     def _create_datasource(name: str, type: str, access: str):
-        grafana = GrafanaSearch.grafana_client_factory(docker_grafana)
+        grafana = GrafanaWtf.grafana_client_factory(docker_grafana)
         # TODO: Add fixture which completely resets everything in Grafana before running the test harness.
         #       Move to a different port than 3000 then!
         try:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -241,3 +241,12 @@ def test_info(docker_grafana, capsys, caplog):
 
     # Proof the output is correct.
     assert list(data.keys()) == ["grafana", "statistics", "summary"]
+
+    assert "version" in data["grafana"]
+    assert "url" in data["grafana"]
+
+    assert "dashboards" in data["summary"]
+    assert "datasources" in data["summary"]
+    assert "dashboard_panels" in data["summary"]
+    assert "dashboard_annotations" in data["summary"]
+    assert "dashboard_templating" in data["summary"]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -226,3 +226,18 @@ def find_all_missing_datasources(data):
         if "datasources_missing" in item:
             missing_names += map(operator.itemgetter("name"), item["datasources_missing"])
     return missing_names
+
+
+def test_info(docker_grafana, capsys, caplog):
+
+    # Which subcommand to test?
+    set_command("info", "--format=yaml")
+
+    # Run command and capture YAML output.
+    with caplog.at_level(logging.DEBUG):
+        grafana_wtf.commands.run()
+    captured = capsys.readouterr()
+    data = yaml.safe_load(captured.out)
+
+    # Proof the output is correct.
+    assert list(data.keys()) == ["grafana", "statistics", "summary"]


### PR DESCRIPTION
Hi again,

this patch will add the `grafana-wtf info` subcommand. It will display the Grafana version and _global statistics_ about many entities. Please let me know you if you are missing anything important. _Per-entity statistics_ will be tackled with #18.

Data for the `statistics` slot is coming from Grafana's `/admin/stats` endpoint. Data for the `summary` slot is computed by `grafana-wtf` itself.

With kind regards,
Andreas.

/cc @jangaraj

#### Example
```shell
$ grafana-wtf info --format=yaml
```

```yaml
grafana:
  version: 8.3.2
  url: http://localhost:3000
statistics:
  activeAdmins: 1
  activeEditors: 0
  activeSessions: 0
  activeUsers: 1
  activeViewers: 0
  admins: 1
  alerts: 0
  dailyActiveAdmins: 0
  dailyActiveEditors: 0
  dailyActiveSessions: 0
  dailyActiveUsers: 1
  dailyActiveViewers: 0
  dashboards: 1
  datasources: 3
  editors: 0
  monthlyActiveUsers: 1
  orgs: 1
  playlists: 0
  snapshots: 0
  stars: 0
  tags: 2
  users: 1
  viewers: 0
summary:
  annotations: 0
  dashboards: 1
  datasources: 3
  folders: 1
  notifications: 0
  organizations: 1
  snapshots: 0
  teams: 0
  users: 1
  dashboard_panels: 11
  dashboard_annotations: 1
  dashboard_templating: 5
```
