### PR TITLE
Add `Dockerfile` and GHA recipe to publish container images to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+*
+
+!*.py
+!*.rst
+!*.txt
+!*.cfg
+!*.toml
+!LICENSE
+!MANIFEST.in
+
+!grafana_wtf

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,99 @@
+# Stage Docker images through GitHub Actions (GHA) to GitHub Container Registry (GHCR).
+#
+# https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md
+# https://github.com/crazy-max/ghaction-docker-meta
+# https://github.com/docker/build-push-action
+
+name: Build and release container images
+
+on:
+  schedule:
+    - cron: '0 10 * * *' # everyday at 10am
+  push:
+    tags:
+      - '*.*.*'
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+
+env:
+  GHCR_IMAGE_NAME: ghcr.io/panodata/grafana-wtf
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # List of Docker images to use as base name for tags
+          images: |
+            ${{ env.GHCR_IMAGE_NAME }}
+          # Generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule,pattern=nightly
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      -
+        name: Inspect meta
+        run: |
+          echo "Tags:      ${{ steps.meta.outputs.tags }}"
+          echo "Labels:    ${{ steps.meta.outputs.labels }}"
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
+        name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+      -
+        name: Login to GHCR
+        # Prevent uploading images for pull requests.
+        # if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Prevent uploading images for pull requests.
+          # push: ${{ github.event_name != 'pull_request' }}
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      -
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ in progress
 - Add example how to print the Grafana version using the ``info`` subcommand
 - Add more information about dashboard entities to ``info`` subcommand
 - Blackify code base
+- Add ``Dockerfile`` and GHA recipe to publish container images to GHCR
 
 2021-12-10 0.11.1
 =================

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.9-slim-bullseye
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV TERM linux
+
+# Install prerequisites
+RUN apt-get update
+RUN apt-get --yes install jq
+
+# Provide sources
+COPY . /app
+
+# Install package
+WORKDIR /app
+RUN python setup.py install

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,14 @@ Display 50 most recent changes across all dashboards.
 
     grafana-wtf log --number=50
 
+Run with Docker::
+
+    # Access Grafana instance on localhost, without authentication.
+    docker run --rm -it --env GRAFANA_URL="http://host.docker.internal:3000" ghcr.io/panodata/grafana-wtf grafana-wtf info
+
+    # Access Grafana instance with authentication.
+    docker run --rm -it --env GRAFANA_URL="https://daq.grafana.org/grafana" --env GRAFANA_TOKEN="eyJrIjoiWHg...dGJpZCI6MX0=" ghcr.io/panodata/grafana-wtf grafana-wtf info
+
 
 ***********
 Screenshots

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -6,7 +6,6 @@ grafana-wtf backlog
 ******
 Prio 1
 ******
-- [o] Dockerize
 - [o] Statistics reports for data sources and panels: https://github.com/panodata/grafana-wtf/issues/18
 - [o] Finding invalid data sources: https://github.com/panodata/grafana-wtf/issues/19
 - [o] Add test fixture for adding dashboards at runtime from branch ``amo/test-dashboard-runtime``
@@ -57,3 +56,4 @@ Done
     - Display Grafana version: https://grafana.com/docs/grafana/latest/http_api/other/#health-api
     - Display number of dashboards, folders, users, and playlists
 - [x] Blackify
+- [x] Dockerize


### PR DESCRIPTION
Some users might prefer to run `grafana-wtf` in cloud environments or don't want to fuzz with the installation on Python.

### Example

```shell
# Access Grafana instance on localhost, without authentication.
docker run --rm -it --env GRAFANA_URL="http://host.docker.internal:3000" ghcr.io/panodata/grafana-wtf grafana-wtf log

# Access Grafana instance with authentication.
docker run --rm -it --env GRAFANA_URL="https://daq.grafana.org/grafana" --env GRAFANA_TOKEN="eyJrIjoiWHg...dGJpZCI6MX0=" ghcr.io/panodata/grafana-wtf grafana-wtf log
```
