### PR TITLE
Minor updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ] # , macos-latest, windows-latest ]
         python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
-        grafana-version: [ "6.7.6", "7.5.12", "8.3.2" ]
+        grafana-version: [ "6.7.6", "7.5.12", "8.3.3" ]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip

--- a/grafana_wtf/commands.py
+++ b/grafana_wtf/commands.py
@@ -87,6 +87,12 @@ def run():
       # Display only dashboards which have missing data sources, along with their names.
       grafana-wtf explore dashboards --format=json | jq '.[] | select( .datasources_missing ) | .dashboard + {ds_missing: .datasources_missing[] | [.name]}'
 
+      # Display all dashboards which use a specific data source, filtered by data source name.
+      grafana-wtf explore dashboards --format=json | jq 'select( .[] | .datasources | .[].name=="<datasource_name>" )'
+
+      # Display all dashboards using data sources with a specific type. Here: InfluxDB.
+      grafana-wtf explore dashboards --format=json | jq 'select( .[] | .datasources | .[].type=="influxdb" )'
+
 
     Find dashboards and data sources:
 


### PR DESCRIPTION
- CI: Use most recent Grafana 8.3.3.
- Add two more examples about using explore dashboards with jq.
  - Display all dashboards which use a specific data source, by name.
  - Display all dashboards using data sources with a specific type.
