### PR TITLE
Switch to the `grafana-client` library fork

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ grafana-wtf changelog
 in progress
 ===========
 
+2022-02-03 0.13.1
+=================
+- Switch to the ``grafana-client`` library fork
+
 2022-01-22 0.13.0
 =================
 - CI: Use most recent Grafana 8.3.3

--- a/grafana_wtf/monkey.py
+++ b/grafana_wtf/monkey.py
@@ -15,11 +15,11 @@ def update_dashboard(self, dashboard):
             dashboard["folderId"] = dashboard["meta"]["folderId"]
 
     put_dashboard_path = "/dashboards/db"
-    r = self.api.POST(put_dashboard_path, json=dashboard)
+    r = self.client.POST(put_dashboard_path, json=dashboard)
     return r
 
 
-def monkeypatch_grafana_api():
-    import grafana_api.api.dashboard as dashboard
+def monkeypatch_grafana_client():
+    import grafana_client.elements.dashboard as dashboard
 
     dashboard.Dashboard.update_dashboard = update_dashboard

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requires = [
     "tqdm>=4.37.0,<5",
     # Grafana
     "requests>=2.23.0,<3",
-    "grafana-api>=1.0.3,<2",
+    "grafana-client>=2,<3",
     "jsonpath-rw>=1.4.0,<2",
     # Caching
     "requests-cache>=0.5.2,<1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import re
 from pathlib import Path
 
 import pytest
-from grafana_api.grafana_api import GrafanaClientError
+from grafana_client.client import GrafanaClientError
 
 from grafana_wtf.core import GrafanaWtf
 


### PR DESCRIPTION
Hi.

This patch makes `grafana-wtf` compatible with the `grafana-client` library fork, see https://github.com/m0nhawk/grafana_api/issues/88.

With kind regards,
Andreas.
