### PR TITLE
Improve tests and fix implementation flaw

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ in progress
   all resources provisioned to Grafana.
 - Tests: Improve test quality, specifically for ``explore dashboards`` on
   Grafana 6 vs. Grafana >= 7
+- Tests: Make test case for `explore datasources` use _two_ data sources
 
 
 2022-02-03 0.13.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ in progress
 - Tests: Disable caching in test mode
 - Tests: Make test suite clean up its provisioned assets from Grafana
 - Tests: Run Grafana on non-standard port 33333
+- Tests: Add flag ``CLEANUP_RESOURCES`` to determine whether to clean up
+  all resources provisioned to Grafana.
 
 
 2022-02-03 0.13.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ in progress
 - Tests: Improve test quality, specifically for ``explore dashboards`` on
   Grafana 6 vs. Grafana >= 7
 - Tests: Make test case for `explore datasources` use _two_ data sources
+- Tests: Mimic Grafana 7/8 on datasource references within dashboards, newer
+  versions have objects (uid, type) instead of bare names
 
 
 2022-02-03 0.13.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ in progress
 - Tests: Run Grafana on non-standard port 33333
 - Tests: Add flag ``CLEANUP_RESOURCES`` to determine whether to clean up
   all resources provisioned to Grafana.
+- Tests: Improve test quality, specifically for ``explore dashboards`` on
+  Grafana 6 vs. Grafana >= 7
 
 
 2022-02-03 0.13.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ in progress
 - Tests: Make test case for `explore datasources` use _two_ data sources
 - Tests: Mimic Grafana 7/8 on datasource references within dashboards, newer
   versions have objects (uid, type) instead of bare names
+- Fix implementation flaw reported at #32. Thanks, @IgorOhrimenko and @carpenterbees!
 
 
 2022-02-03 0.13.1

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -7,6 +7,8 @@ grafana-wtf backlog
 Prio 1
 ******
 - [o] With Grafana >8.3, resolve datasource name and add to ``{'type': 'influxdb', 'uid': 'PDF2762CDFF14A314'}``
+- [o] Add "folder name/uid" to "explore dashboards" response.
+- [o] Check if "datasources" is always present in responses to "explore dashboards".
 
 
 *********
@@ -27,6 +29,7 @@ Prio 1.5
 - [o] Show dependencies
 - [o] Optionally apply "replace" to data sources also
 - [o] Add software tests for authenticated access to Grafana (--grafana-token)
+- [o] Add output format RSS
 
 
 ******

--- a/grafana_wtf/commands.py
+++ b/grafana_wtf/commands.py
@@ -148,7 +148,7 @@ def run():
     setup_logging(log_level)
 
     # Debugging
-    log.debug("Options: {}".format(json.dumps(options, indent=4)))
+    # log.debug("Options: {}".format(json.dumps(options, indent=4)))
 
     configure_http_logging(options)
 

--- a/grafana_wtf/core.py
+++ b/grafana_wtf/core.py
@@ -495,7 +495,7 @@ class Indexer:
                     ds = dict(ds)
                 if ds not in items:
                     items.append(ds)
-        return sorted(items)
+        return items
 
     def index_dashboards(self):
 

--- a/grafana_wtf/core.py
+++ b/grafana_wtf/core.py
@@ -295,6 +295,17 @@ class GrafanaWtf(GrafanaEngine):
 
         return response
 
+    def version(self):
+
+        try:
+            health = self.grafana.client.GET("/health")
+        except Exception as ex:
+            log.error(f"Request to /health endpoint failed: {ex}")
+            health = {}
+
+        version = health.get("version")
+        return version
+
     def dashboard_details(self):
         for dashboard in self.data.dashboards:
             yield DashboardDetails(dashboard=dashboard)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ requires = [
 
 extras = {
     "test": [
-        "pytest>=5,<7",
+        "pytest>=5,<8",
         "lovely-pytest-docker>=0.2.1,<3",
         "grafanalib>=0.6,<0.7",
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,9 @@ from grafanalib._gen import write_dashboard
 
 from grafana_wtf.core import GrafanaWtf
 
+# Whether to clean up all resources provisioned to Grafana.
+CLEANUP_RESOURCES = True
+
 
 # Make sure development or production settings don't leak into the test suite.
 def clean_environment():
@@ -78,9 +81,10 @@ def create_datasource(docker_grafana):
 
     yield _create_datasource
 
-    if datasource_ids:
-        for datasource_id in datasource_ids:
-            grafana.datasource.delete_datasource_by_id(datasource_id)
+    if CLEANUP_RESOURCES:
+        if datasource_ids:
+            for datasource_id in datasource_ids:
+                grafana.datasource.delete_datasource_by_id(datasource_id)
 
 
 @pytest.fixture
@@ -141,9 +145,10 @@ def create_folder(docker_grafana):
     yield _create_folder
 
     # Delete dashboard again.
-    if folder_uids:
-        for folder_uid in folder_uids:
-            grafana.folder.delete_folder(uid=folder_uid)
+    if CLEANUP_RESOURCES:
+        if folder_uids:
+            for folder_uid in folder_uids:
+                grafana.folder.delete_folder(uid=folder_uid)
 
 
 @pytest.fixture
@@ -182,9 +187,10 @@ def create_dashboard(docker_grafana):
     yield _create_dashboard
 
     # Delete dashboard again.
-    if dashboard_uids:
-        for dashboard_uid in dashboard_uids:
-            grafana.dashboard.delete_dashboard(dashboard_uid=dashboard_uid)
+    if CLEANUP_RESOURCES:
+        if dashboard_uids:
+            for dashboard_uid in dashboard_uids:
+                grafana.dashboard.delete_dashboard(dashboard_uid=dashboard_uid)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -313,15 +313,22 @@ def grafana_version(docker_grafana):
     return grafana_version
 
 
-def mkdashboard(title: str, datasource: str):
+def mkdashboard(title: str, datasources: List[str]):
     """
-    Build dashboard with single panel.
+    Build dashboard with multiple panels, each with a different data source.
     """
     # datasource = grafanalib.core.DataSourceInput(name="foo", label="foo", pluginId="foo", pluginName="foo")
-    panel_gl = grafanalib.core.Panel(dataSource=datasource, gridPos={"h": 1, "w": 24, "x": 0, "y": 0})
-    dashboard_gl = grafanalib.core.Dashboard(title=title, panels=[panel_gl.panel_json(overrides={})])
+
+    # Build dashboard object model.
+    panels = []
+    for datasource in datasources:
+        panel = grafanalib.core.Panel(dataSource=datasource, gridPos={"h": 1, "w": 24, "x": 0, "y": 0})
+        panels.append(panel.panel_json(overrides={}))
+    dashboard = grafanalib.core.Dashboard(title=title, panels=panels)
+
+    # Render dashboard to JSON.
     dashboard_json = StringIO()
-    write_dashboard(dashboard_gl, dashboard_json)
+    write_dashboard(dashboard, dashboard_json)
     dashboard_json.seek(0)
     dashboard = json.loads(dashboard_json.read())
     return dashboard

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -245,9 +245,9 @@ def test_log_tabular_success(ldi_resources, capsys, caplog):
 def test_explore_datasources_used(create_datasource, create_dashboard, capsys, caplog):
 
     # Create two data sources and a dashboard which uses them.
-    create_datasource(name="foo")
-    create_datasource(name="bar")
-    create_dashboard(mkdashboard(title="baz", datasources=["foo", "bar"]))
+    ds_foo = create_datasource(name="foo")
+    ds_bar = create_datasource(name="bar")
+    create_dashboard(mkdashboard(title="baz", datasources=[ds_foo, ds_bar]))
 
     # Compute breakdown.
     set_command("explore datasources", "--format=yaml")


### PR DESCRIPTION
This patch does a few things.

- Tests: Improve test quality, specifically for `explore dashboards`.
  Grafana 6 vs. Grafana >= 7 have a different behaviour here because Grafana 6 did not know about data source UIDs yet.
- Tests: Make test case for `explore datasources` use _two_ data sources.
- Tests: Mimic Grafana 7/8 on datasource references within dashboards.
  Newer versions have objects (uid, type) instead of bare names. This improvement reveals an implementation flaw.
- Fix implementation flaw with 6e3b440efb.

Kudos to @IgorOhrimenko and @carpenterbees for reporting this bug at #32.
