### PR TITLE
Add option to ignore untrusted SSL certificates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,11 @@ grafana-wtf changelog
 in progress
 ===========
 
-2022-02-03 0.13.2
+2022-03-25 0.13.3
+=================
+- Add option to ignore untrusted SSL certificates. Thanks, @billabongrob!
+
+2022-03-25 0.13.2
 =================
 - Use ``grafana-client-2.1.0``, remove monkeypatch
 - Tests: Improve fixture ``create_datasource`` to clean up afterwards

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ grafana-wtf - grep through all Grafana entities in the spirit of `git-wtf`_.
 ********
 Synopsis
 ********
+
 Search Grafana API for string "weatherbase".
 ::
 
@@ -109,6 +110,11 @@ Before running ``grafana-wtf``, define URL and access token of your Grafana inst
 
     export GRAFANA_URL=https://daq.example.org/grafana/
     export GRAFANA_TOKEN=eyJrIjoiWHg...dGJpZCI6MX0=
+
+In order to ignore untrusted SSL certificates, append the ``?verify=no`` query string
+to the ``GRAFANA_URL``::
+
+    export GRAFANA_URL=https://daq.example.org/grafana/?verify=no
 
 
 General information

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -16,6 +16,7 @@ Prio 1.25
 *********
 - [o] Statistics reports for data sources and panels: https://github.com/panodata/grafana-wtf/issues/18
 - [o] Finding invalid data sources: https://github.com/panodata/grafana-wtf/issues/19
+- [o] Add subcommand ``dump`` for dumping whole documents from the API, unmodified
 
 
 ********

--- a/grafana_wtf/util.py
+++ b/grafana_wtf/util.py
@@ -124,3 +124,37 @@ def yaml_dump(data, stream=None, Dumper=yaml.SafeDumper, **kwds):
 
     OrderedDumper.add_representer(OrderedDict, _dict_representer)
     return yaml.dump(data, stream, OrderedDumper, **kwds)
+
+
+def as_bool(value: str) -> bool:
+    """
+    Given a string value that represents True or False, returns the Boolean equivalent.
+    Heavily inspired from distutils strtobool.
+
+    From `isort`: https://github.com/PyCQA/isort/blob/5.10.1/isort/settings.py#L915-L922
+    """
+
+    if value is None:
+        return False
+
+    if isinstance(value, bool):
+        return value
+
+    _STR_BOOLEAN_MAPPING = {
+        "y": True,
+        "yes": True,
+        "t": True,
+        "on": True,
+        "1": True,
+        "true": True,
+        "n": False,
+        "no": False,
+        "f": False,
+        "off": False,
+        "0": False,
+        "false": False,
+    }
+    try:
+        return _STR_BOOLEAN_MAPPING[value.lower()]
+    except KeyError:
+        raise ValueError(f"invalid truth value {value}")


### PR DESCRIPTION
This patch implements the possibility to ignore untrusted SSL certificates, as suggested by @billabongrob at #31.

It can be used by appending the `?verify=no` query string to the `GRAFANA_URL`:

    export GRAFANA_URL=https://daq.example.org/grafana/?verify=no
