### PR TITLE
CI: Use most recent Grafana 7.5.16, 8.5.5, and 9.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ] # , macos-latest, windows-latest ]
         python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
-        grafana-version: [ "6.7.6", "7.5.15", "8.4.4" ]
+        grafana-version: [ "6.7.6", "7.5.16", "8.5.5", "9.0.0" ]
         include:
         - os: ubuntu-latest
           path: ~/.cache/pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ grafana-wtf changelog
 
 in progress
 ===========
+- CI: Use most recent Grafana 7.5.16, 8.5.5, and 9.0.0-beta3
 
 2022-03-25 0.13.3
 =================

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@
 .. image:: https://img.shields.io/pypi/l/grafana-wtf.svg
     :target: https://github.com/panodata/grafana-wtf/blob/main/LICENSE
 
-.. image:: https://img.shields.io/badge/Grafana-6.x%20--%208.x-blue.svg
+.. image:: https://img.shields.io/badge/Grafana-6.x%20--%209.x-blue.svg
     :target: https://github.com/grafana/grafana
     :alt: Supported Grafana versions
 


### PR DESCRIPTION
What the title says.

Edit: What a coincidence. Grafana 9 has been released just some minutes ago.

![image](https://user-images.githubusercontent.com/453543/173613124-d556438b-f243-497e-b693-f1f651a055ed.png)
