### PR TITLE
Fix dashboard exploration when the `annotations.list` slot is `None`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ grafana-wtf changelog
 in progress
 ===========
 - CI: Use most recent Grafana 7.5.16, 8.5.5, and 9.0.0-beta3
+- Fix dashboard exploration when the ``annotations.list`` slot is ``None``
+  instead of an empty list. Thanks, @TaylorMutch!
 
 2022-03-25 0.13.3
 =================

--- a/grafana_wtf/core.py
+++ b/grafana_wtf/core.py
@@ -497,6 +497,7 @@ class Indexer:
 
     @staticmethod
     def collect_datasource_items(element):
+        element = element or []
         items = []
         for node in element:
             if "datasource" in node and node["datasource"]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import os
 import re
 from io import StringIO
 from pathlib import Path
-from typing import List, Union
+from typing import List, Union, Optional
 
 import grafanalib.core
 import pytest
@@ -321,11 +321,13 @@ def grafana_version(docker_grafana):
     return grafana_version
 
 
-def mkdashboard(title: str, datasources: List[str]):
+def mkdashboard(title: str, datasources: Optional[List[str]] = None):
     """
     Build dashboard with multiple panels, each with a different data source.
     """
     # datasource = grafanalib.core.DataSourceInput(name="foo", label="foo", pluginId="foo", pluginName="foo")
+
+    datasources = datasources or []
 
     # Build dashboard object model.
     panels = []


### PR DESCRIPTION
Hi there,

@TaylorMutch reported at #36 that `grafana-wtf explore dashboards` croaks for him.

> It looks like one of the dashboards you are requesting has an **unassigned** `annotations` slot, i.e. its value equals `None`. The code probably expects it to be an **empty list** instead. 

After looking into this, we found that was exactly the case. This patch makes the gathering process more graceful to compensate for such a situation.

With kind regards,
Andreas.