### PR TITLE
CI: Fix `release-docker` workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY . /app
 
 # Install package
 WORKDIR /app
-RUN python setup.py install
+RUN pip install .

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,5 +1,5 @@
-bump2version>=1,<2
-twine>=2,<4
-keyring>=17,<24
-black==21.12b0
-isort==5.10.1
+bump2version<2
+twine<5
+keyring<24
+black<23
+isort<6

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ requires = [
 
 extras = {
     "test": [
-        "pytest>=5,<8",
-        "lovely-pytest-docker>=0.2.1,<3",
-        "grafanalib>=0.6,<0.7",
+        "pytest<8",
+        "lovely-pytest-docker<1",
+        "grafanalib<0.7",
     ]
 }
 


### PR DESCRIPTION
Fix for:

```
#18 6.574 error: urllib3 2.0.0a1 is installed but urllib3<1.27,>=1.21.1 is required by {'requests'}
```

-- https://github.com/panodata/grafana-wtf/actions/runs/3478374517/jobs/5815665994#step:10:597