### PR TITLE
Add URLs to dashboard variables and panel view/edit pages to the output of the "find" subcommand

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ in progress
 ===========
 - Add ``--dry-run`` option for ``replace`` subcommand. Thanks, @TaylorMutch.
 - Update dependencies to their most recent versions.
+- Add URLs to dashboard variables and panel view/edit pages to the output of
+  the ``find`` subcommand. Thanks, @oplehto.
 
 2022-06-19 0.13.4
 =================

--- a/grafana_wtf/util.py
+++ b/grafana_wtf/util.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # (c) 2019-2021 Andreas Motl <andreas@hiveeyes.org>
 # License: GNU Affero General Public License, Version 3
+import io
 import json
 import logging
 import sys
@@ -155,3 +156,12 @@ def as_bool(value: str) -> bool:
         return _STR_BOOLEAN_MAPPING[value.lower()]
     except KeyError:
         raise ValueError(f"invalid truth value {value}")
+
+
+def format_dict(data) -> str:
+    output = io.StringIO()
+    for key, value in data.items():
+        entry = f" {key:>12} {value}\n"
+        output.write(entry)
+    output.seek(0)
+    return output.read().rstrip()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -83,7 +83,13 @@ def test_find_textual_dashboard_success(ldi_resources, capsys):
     assert "Title luftdaten.info generic trend" in captured.out
     assert "Folder Testdrive" in captured.out
     assert "UID ioUrPwQiz" in captured.out
-    assert "URL http://localhost:33333/d/ioUrPwQiz/luftdaten-info-generic-trend" in captured.out
+    assert "Dashboard http://localhost:33333/d/jpVsQxRja/luftdaten-info-generic-trend-v33" in captured.out
+    assert (
+        "Variables http://localhost:33333/d/jpVsQxRja/luftdaten-info-generic-trend-v33?editview=templating"
+        in captured.out
+    )
+    assert "View http://localhost:33333/d/jpVsQxRja/luftdaten-info-generic-trend-v33?viewPanel=17" in captured.out
+    assert "Edit http://localhost:33333/d/jpVsQxRja/luftdaten-info-generic-trend-v33?editPanel=17" in captured.out
     assert "dashboard.panels.[1].targets.[0].measurement: ldi_readings" in captured.out
     assert "dashboard.panels.[7].panels.[0].targets.[0].measurement: ldi_readings" in captured.out
 


### PR DESCRIPTION
This patch adds direct URLs to dashboard variables (`editview=templating`), and to panel view/edit pages (`viewPanel=`, `editPanel=`) to the output of the "find" subcommand, as requested by @oplehto at GH-43.

![image](https://user-images.githubusercontent.com/453543/217396502-beb3b96a-6ff9-4418-8ceb-6ee539d1f94f.png)
