### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,9 +48,10 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'setup.py'
 
-      - name: Install program
+      - name: Setup Project
         run: |
-          pip install --editable=.[test]
+          pip install pip 'setuptools>=64' --upgrade
+          pip install --editable='.[test]'
 
       - name: Run tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest" ]
-        python-version: [ "3.7", "3.11" ]
+        python-version: [ "3.7", "3.11", "3.12" ]
         grafana-version: [ "6.7.6", "7.5.17", "8.5.27", "9.5.18", "10.3.5", "10.4.1" ]
 
     env:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ in progress
 - Dependencies: Use ``verlib2`` instead of ``packaging``
 - Dependencies: Updated to ``docopt-ng``
 - Add subcommand ``explore permissions``. Thanks, @meyerder.
+- Added support for Python 3.12
 
 2024-03-07 0.18.0
 =================

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ $(eval isort        := $(venvpath)/bin/isort)
 # Setup Python virtualenv
 setup-virtualenv:
 	@test -e $(python) || python3 -m venv $(venvpath)
+	@$(pip) install --upgrade setuptools
 
 
 # -------

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Communications",
         "Topic :: Database",
         "Topic :: Internet",


### PR DESCRIPTION
## About
Add Python 3.12 to CI.

## References
- https://github.com/numpy/numpy/issues/23808#issuecomment-1676838801
- https://github.com/duckdb/duckdb/issues/9301#issuecomment-1756731027
- https://github.com/duckdb/duckdb/pull/9222
