### PR TITLE
Modernize caching and progressbar, and drop support for Python 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ "ubuntu-20.04" ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        os: [ "ubuntu-latest" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
         grafana-version: [ "6.7.6", "7.5.17", "8.5.15", "9.2.7" ]
 
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 /.venv*
 /var
 /dist
-cache.sqlite

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ in progress
 - Improve caching
 
   - Use cache database location within user folder
-  - c cache database location to log
+  - Send cache database location to log
   - Reduce default cache TTL from five minutes to 60 seconds
 - Drop support for Python 3.6
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ in progress
 - Add URLs to dashboard variables and panel view/edit pages to the output of
   the ``find`` subcommand. Thanks, @oplehto.
 - Improve display of progressbar wrt. being interrupted by logging output.
+- Improve caching
+
+  - Use cache database location within user folder
+  - c cache database location to log
+  - Reduce default cache TTL from five minutes to 60 seconds
 
 2022-06-19 0.13.4
 =================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ in progress
 - Update dependencies to their most recent versions.
 - Add URLs to dashboard variables and panel view/edit pages to the output of
   the ``find`` subcommand. Thanks, @oplehto.
+- Improve display of progressbar wrt. being interrupted by logging output.
 
 2022-06-19 0.13.4
 =================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ in progress
   - Use cache database location within user folder
   - c cache database location to log
   - Reduce default cache TTL from five minutes to 60 seconds
+- Drop support for Python 3.6
 
 2022-06-19 0.13.4
 =================

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -11,6 +11,7 @@ Prio 1
 - [o] Add subcommand for checking data source health
 - [o] Provide environment variable for ``--drop-cache``
 - [o] Does it croak on play.grafana.org?
+- [o] Don't display "Global" section when it's mostly empty.
 
 
 *********

--- a/grafana_wtf/commands.py
+++ b/grafana_wtf/commands.py
@@ -45,7 +45,7 @@ def run():
       --select-dashboard=<uuid>         Restrict operation to dashboard by UID.
                                         Can be a list of comma-separated dashboard UIDs.
       --format=<format>                 Output format. [default: json]
-      --cache-ttl=<cache-ttl>           Time-to-live for the request cache in seconds. [default: 300]
+      --cache-ttl=<cache-ttl>           Time-to-live for the request cache in seconds. [default: 60]
       --drop-cache                      Drop cache before requesting resources
       --concurrency=<concurrency>       Run multiple requests in parallel. [default: 5]
       --dry-run                         Dry-run mode for the `replace` subcommand.

--- a/grafana_wtf/core.py
+++ b/grafana_wtf/core.py
@@ -9,6 +9,7 @@ import warnings
 from collections import OrderedDict
 from concurrent.futures.thread import ThreadPoolExecutor
 from urllib.parse import parse_qs, urljoin, urlparse
+from tqdm.contrib.logging import tqdm_logging_redirect
 
 import colored
 import requests
@@ -108,7 +109,8 @@ class GrafanaEngine:
 
     def start_progressbar(self, total):
         if self.progressbar:
-            self.taqadum = tqdm(total=total)
+            with tqdm_logging_redirect():
+                self.taqadum = tqdm(total=total)
 
     def scan_common(self):
         self.scan_dashboards()

--- a/grafana_wtf/core.py
+++ b/grafana_wtf/core.py
@@ -48,13 +48,16 @@ class GrafanaEngine:
         self.debug = log.getEffectiveLevel() == logging.DEBUG
         self.progressbar = not self.debug
 
-    def enable_cache(self, expire_after=300, drop_cache=False):
+    def enable_cache(self, expire_after=60, drop_cache=False):
         if expire_after is None:
-            log.info(f"Setting up response cache to never expire (infinite caching)")
+            log.info(f"Configure response cache to never expire (infinite caching)")
         else:
-            log.info(f"Setting up response cache to expire after {expire_after} seconds")
-        requests_cache.install_cache(expire_after=expire_after)
+            log.info(f"Configure response cache to expire after {expire_after} seconds")
+        requests_cache.install_cache(expire_after=expire_after, use_cache_dir=True)
+        cache_database_file = requests_cache.get_cache().db_path
+        log.info(f"Response cache database location is {cache_database_file}")
         if drop_cache:
+            log.info("Dropping response cache")
             self.clear_cache()
 
         return self

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requires = [
     "grafana-client>=2.1.0,<4",
     "jsonpath-rw>=1.4.0,<2",
     # Caching
-    "requests-cache>=0.5.2,<1",
+    "requests-cache>=0.8.0,<1",
     # Output
     "tabulate>=0.8.5,<0.10",
     "colored>=1.4.3,<2",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         "Operating System :: Unix",
         "Operating System :: MacOS",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requires = [
     'dataclasses; python_version<"3.7"',
     "docopt>=0.6.2,<0.7",
     "munch>=2.5.0,<3",
-    "tqdm>=4.37.0,<5",
+    "tqdm>=4.60.0,<5",
     # Grafana
     "requests>=2.23.0,<3",
     "grafana-client>=2.1.0,<4",


### PR DESCRIPTION
- Improve display of progressbar wrt. being interrupted by logging output: 5bd006f34
- Improve caching: 9bf1f65677
  - Use cache database location within user folder
  - Send cache database location to log
  - Reduce default cache TTL from five minutes to 60 seconds
- Because of the dependency to a more recent `requests-cache` package, this patch also drops support for Python 3.6.