### PR TITLE
Fix `collect_datasource_items` when hitting special templated datasource

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ grafana-wtf changelog
 
 in progress
 ===========
+- Fix ``collect_datasource_items`` when hitting special templated datasource.
+  Thanks, @mauhiz.
 
 2023-02-09 0.14.0
 =================

--- a/grafana_wtf/util.py
+++ b/grafana_wtf/util.py
@@ -165,3 +165,9 @@ def format_dict(data) -> str:
         output.write(entry)
     output.seek(0)
     return output.read().rstrip()
+
+
+def to_list(value):
+    if not isinstance(value, list):
+        value = [value]
+    return value

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,37 @@
+from unittest.mock import Mock
+
+from munch import Munch
+
+from grafana_wtf.core import Indexer
+
+
+def test_collect_datasource_items_variable_all():
+    """
+    Verify fix for `TypeError: unhashable type: 'list'` in `collect_datasource_items`.
+
+    https://github.com/panodata/grafana-wtf/issues/62
+    """
+    node = Munch(
+        {
+            "current": Munch({"selected": True, "text": ["All"], "value": ["$__all"]}),
+            "hide": 0,
+            "includeAll": True,
+            "multi": True,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "/.*-storage$/",
+            "skipUrlSync": False,
+            "type": "datasource",
+        }
+    )
+    engine_mock = Mock(
+        scan_datasources=Mock(return_value=[]),
+        scan_dashboards=Mock(return_value=[]),
+        dashboard_details=Mock(return_value=[]),
+    )
+    indexer = Indexer(engine=engine_mock)
+    result = indexer.collect_datasource_items([node])
+    assert result == []


### PR DESCRIPTION
Dear @mauhiz,

this patch may fix the issue you reported at GH-62. The machinery croaked on `"value": ["$__all"]` when finding a templated datasource within a dashboard representation. Because `$__all` will not resolve to a specific data source, this item will get skipped now, but a warning will be emitted.

Thank you very much for your valuable hints about the origin of the problem.

With kind regards,
Andreas.
