### PR TITLE
History: Add SQL querying capabilities

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ in progress
 - History: Unlock YAML export format
 - History: Add new options ``--head``, ``--tail``, and ``--reverse``
 - Search: Unlock JSON and YAML export formats
+- History: Add SQL querying capabilities
 
 2023-03-05 0.14.1
 =================

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY . /app
 
 # Install package
 WORKDIR /app
-RUN pip install .
+RUN pip install --prefer-binary .

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ requires = [
     "docopt>=0.6.2,<0.7",
     "munch>=2.5.0,<3",
     "tqdm>=4.60.0,<5",
+    # Filtering
+    "pandas<1.6",
+    "duckdb<0.8",
     # Grafana
     "requests>=2.23.0,<3",
     "grafana-client>=2.1.0,<4",

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ from setuptools import find_packages, setup
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, "README.rst")).read()
 
+no_linux_on_arm = "platform_system != 'Linux' or (platform_machine != 'armv7l' and platform_machine != 'aarch64')"
+
 requires = [
     # Core
     "six",
@@ -14,8 +16,8 @@ requires = [
     "munch>=2.5.0,<3",
     "tqdm>=4.60.0,<5",
     # Filtering
-    "pandas<1.6",
-    "duckdb<0.8",
+    f"pandas<1.6; {no_linux_on_arm}",
+    f"duckdb<0.8; {no_linux_on_arm}",
     # Grafana
     "requests>=2.23.0,<3",
     "grafana-client>=2.1.0,<4",


### PR DESCRIPTION
Hi there,

at Hiveeyes, we needed to discover all Grafana dashboards with only a single edit, i.e. without any further activity.

![image](https://user-images.githubusercontent.com/453543/222989568-7e4f1ec3-a809-4267-80d9-9e61c032e772.png)

With this patch, adding SQL querying capabilities to the dashboard version history, it is very easy, thanks to pandas and DuckDB [^1].

```sql
SELECT uid, url, COUNT(version) as number_of_edits
FROM dashboard_versions
GROUP BY uid, url
HAVING number_of_edits=1
```

With kind regards,
Andreas.

[^1]: While this example does not emphasize DuckDB's performance characteristics, it is a perfect showcase example how convenient it is to add SQL querying capabilities to data on the library level.

/cc @jangaraj, @hannes, @mytherin
