### PR TITLE
CI: Do not build and publish OCI images on GHA PRs from non-members

### DIFF
--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -32,11 +32,9 @@ env:
 jobs:
 
   docker:
-
-    # To save resources, skip running on commits authored by Dependabot.
-    if: ${{ !contains(github.event.head_commit.author.name, 'dependabot') }}
-
     runs-on: ubuntu-latest
+    if: ${{ ! (startsWith(github.actor, 'dependabot') || github.event.pull_request.head.repo.fork ) }}
+
     steps:
       -
         name: Checkout


### PR DESCRIPTION
The OCI image build machinery can't upload to GHCR when running on behalf of non-members.

### References
- https://github.com/earthobservations/wetterdienst/pull/967
- https://github.com/daq-tools/lorrystream/pull/19
