### PR TITLE
Add `explore dashboards --data-details` option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ in progress
 - CI: Update to Grafana 8.5.27, 9.5.8, and 10.1.1
 - Grafana 9.3: Work around delete folder operation returning empty body
 - Grafana 9.5: Use standard UUIDs instead of short UIDs
+- Add ``explore dashboards --data-details`` option, to extend the output
+  by many more details about data inquiry / queries. Thanks, @meyerder.
 
 2023-07-30 0.15.2
 =================

--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,12 @@ How to find dashboards which use non-existing data sources?
     # Display only dashboards which have missing data sources, along with their names.
     grafana-wtf explore dashboards --format=json | jq '.[] | select( .datasources_missing ) | .dashboard + {ds_missing: .datasources_missing[] | [.name]}'
 
+How to list all queries used in all dashboards?
+::
+
+    grafana-wtf explore dashboards --data-details --format=json | \
+        jq -r '.[].details | values[] | .[].query // "null"'
+
 
 Searching for strings
 =====================

--- a/grafana_wtf/commands.py
+++ b/grafana_wtf/commands.py
@@ -29,7 +29,7 @@ def run():
     Usage:
       grafana-wtf [options] info
       grafana-wtf [options] explore datasources
-      grafana-wtf [options] explore dashboards
+      grafana-wtf [options] explore dashboards [--data-details]
       grafana-wtf [options] find [<search-expression>]
       grafana-wtf [options] replace <search-expression> <replacement> [--dry-run]
       grafana-wtf [options] log [<dashboard_uid>] [--number=<count>] [--head=<count>] [--tail=<count>] [--reverse] [--sql=<sql>]
@@ -91,6 +91,12 @@ def run():
       # Display all dashboards using data sources with a specific type. Here: InfluxDB.
       grafana-wtf explore dashboards --format=json | jq 'select( .[] | .datasources | .[].type=="influxdb" )'
 
+      # Display dashboards and many more details about where data source queries are happening.
+      # Specifically, within "panels/targets", "annotations", and "templating" slots.
+      grafana-wtf explore dashboards --data-details --format=json
+
+      # Display all database queries within dashboards.
+      grafana-wtf explore dashboards --data-details --format=json | jq -r '.[].details | values[] | .[].query // "null"'
 
     Find dashboards and data sources:
 
@@ -298,7 +304,7 @@ def run():
         output_results(output_format, results)
 
     if options.explore and options.dashboards:
-        results = engine.explore_dashboards()
+        results = engine.explore_dashboards(with_data_details=options.data_details)
         output_results(output_format, results)
 
     if options.info:

--- a/grafana_wtf/core.py
+++ b/grafana_wtf/core.py
@@ -447,7 +447,7 @@ class GrafanaWtf(GrafanaEngine):
 
         return response
 
-    def explore_dashboards(self):
+    def explore_dashboards(self, with_data_details: bool = False):
         # Prepare indexes, mapping dashboards by uid, datasources by name
         # as well as dashboards to datasources and vice versa.
         ix = Indexer(engine=self)
@@ -481,8 +481,8 @@ class GrafanaWtf(GrafanaEngine):
                 dashboard=dashboard, datasources=datasources_existing, grafana_url=self.grafana_url
             )
 
-            # Format results in a more compact form, using only a subset of all the attributes.
-            result = item.format_compact()
+            # Format results, using only a subset of all the attributes.
+            result = item.format(with_data_details=with_data_details)
 
             # Add information about missing data sources.
             if datasources_missing:


### PR DESCRIPTION
Dear @meyerder,

related to your request at GH-70, this patch extends the output of `grafana-wtf explore dashboards` by many more details about data inquiry / queries, when adding the `--data-details` option.

When combining it with `jq` in this way, you can generate a flat list of all data queries in use within all dashboards.

```shell
grafana-wtf explore dashboards --data-details --format=json | \
    jq -r '.[].details | values[] | .[].query // "null"'
```

You can install the package directly from the feature branch using this `pip` command.

```shell
pip install --upgrade 'git+https://github.com/panodata/grafana-wtf@amo/explore-dashboards-data-details'
```

I will be happy to hear back from you if you think this is useful in one way or another. If you think it is not enough, and would need further improvements to handle your use case, let me know.

With kind regards,
Andreas.
