### PR TITLE
Add subcommands `plugins {list,status}`, to inquire plugins

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ in progress
 - Grafana 9.5: Use standard UUIDs instead of short UIDs
 - Add ``explore dashboards --data-details`` option, to extend the output
   by many more details about data inquiry / queries. Thanks, @meyerder.
+- Add ``plugins {list,status}`` subcommands, to inquire installed Grafana
+  plugins. Thanks, @bhks.
 
 2023-07-30 0.15.2
 =================

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,12 @@ Explore dashboards and datasources in more detail.
     grafana-wtf explore dashboards
     grafana-wtf explore datasources
 
+Explore plugins.
+::
+
+    grafana-wtf plugins list
+    grafana-wtf plugins status
+
 Run with Docker::
 
     # Access Grafana instance on localhost, without authentication.

--- a/grafana_wtf/commands.py
+++ b/grafana_wtf/commands.py
@@ -37,8 +37,8 @@ def run():
       grafana-wtf [options] find [<search-expression>]
       grafana-wtf [options] replace <search-expression> <replacement> [--dry-run]
       grafana-wtf [options] log [<dashboard_uid>] [--number=<count>] [--head=<count>] [--tail=<count>] [--reverse] [--sql=<sql>]
-      grafana-wtf [options] plugins list
-      grafana-wtf [options] plugins status
+      grafana-wtf [options] plugins list [--id=]
+      grafana-wtf [options] plugins status [--id=]
       grafana-wtf --version
       grafana-wtf (-h | --help)
 
@@ -324,9 +324,15 @@ def run():
 
     if options.plugins:
         if options.list:
-            response = engine.plugins_list()
+            if options.id:
+                response = engine.plugins_list_by_id(options.id)
+            else:
+                response = engine.plugins_list()
         elif options.status:
-            response = engine.plugins_status()
+            if options.id:
+                response = engine.plugins_status_by_id(options.id)
+            else:
+                response = engine.plugins_status()
         else:
             raise DocoptExit('Subcommand "plugins" only provides "list" and "status"')
         output_results(output_format, response)

--- a/grafana_wtf/commands.py
+++ b/grafana_wtf/commands.py
@@ -37,6 +37,8 @@ def run():
       grafana-wtf [options] find [<search-expression>]
       grafana-wtf [options] replace <search-expression> <replacement> [--dry-run]
       grafana-wtf [options] log [<dashboard_uid>] [--number=<count>] [--head=<count>] [--tail=<count>] [--reverse] [--sql=<sql>]
+      grafana-wtf [options] plugins list
+      grafana-wtf [options] plugins status
       grafana-wtf --version
       grafana-wtf (-h | --help)
 
@@ -155,6 +157,14 @@ def run():
         GROUP BY uid, url
         HAVING COUNT(version)=1
       "
+
+    List plugins:
+
+      # Inquire plugin list.
+      grafana-wtf plugins list
+
+      # Inquire plugin health check and metrics endpoints.
+      grafana-wtf plugins status
 
     Cache control:
 
@@ -310,4 +320,13 @@ def run():
 
     if options.info:
         response = engine.info()
+        output_results(output_format, response)
+
+    if options.plugins:
+        if options.list:
+            response = engine.plugins_list()
+        elif options.status:
+            response = engine.plugins_status()
+        else:
+            raise DocoptExit('Subcommand "plugins" only provides "list" and "status"')
         output_results(output_format, response)

--- a/grafana_wtf/core.py
+++ b/grafana_wtf/core.py
@@ -492,6 +492,40 @@ class GrafanaWtf(GrafanaEngine):
 
         return results
 
+    def plugins_list(self):
+        return self.grafana.plugin.get_installed_plugins()
+
+    def plugins_status(self):
+        status = []
+        plugins = self.grafana.plugin.get_installed_plugins()
+        for plugin in plugins:
+            plugin = munchify(plugin)
+            item = Munch(
+                name=plugin.name,
+                type=plugin.type,
+                id=plugin.id,
+                enabled=plugin.enabled,
+                category=plugin.category,
+                version=plugin.info.version,
+                signature=plugin.get("signature"),
+            )
+
+            # Status inquiry is not provided by all plugins. Let's filter them.
+            # Effectively, run it only on non-internal "app" and "datasource" items.
+            if item.type != "panel" and item.signature != "internal":
+                try:
+                    item.health = self.grafana.plugin.health_check_plugin(plugin.id)
+                except Exception as ex:
+                    log.warning(f"Health check failed for plugin {item.id}, type={item.type}: {ex}")
+                try:
+                    item.metrics = self.grafana.plugin.get_plugin_metrics(plugin.id)
+                except Exception as ex:
+                    log.warning(f"Metrics inquiry failed for plugin {item.id}, type={item.type}: {ex}")
+            else:
+                log.info(f"Skipping status inquiry for plugin {item.id}, type={item.type}")
+            status.append(item)
+        return status
+
 
 class Indexer:
     def __init__(self, engine: GrafanaWtf):

--- a/grafana_wtf/util.py
+++ b/grafana_wtf/util.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 def setup_logging(level=logging.INFO):
-    log_format = "%(asctime)-15s [%(name)-22s] %(levelname)-7s: %(message)s"
+    log_format = "%(asctime)-15s [%(name)-36s] %(levelname)-7s: %(message)s"
     logging.basicConfig(format=log_format, stream=sys.stderr, level=level)
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requires = [
     f"duckdb<0.9; {no_linux_on_arm}",
     # Grafana
     "requests>=2.26,<3",
-    "grafana-client>=2.1.0,<4",
+    "grafana-client>=3.8.2,<4",
     "jsonpath-rw>=1.4.0,<2",
     # Caching
     "requests-cache>=0.8.0,<2",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requires = [
     f"duckdb<0.9; {no_linux_on_arm}",
     # Grafana
     "requests>=2.26,<3",
-    "grafana-client>=3.8.2,<4",
+    "grafana-client>=3.9.1,<4",
     "jsonpath-rw>=1.4.0,<2",
     # Caching
     "requests-cache>=0.8.0,<2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def docker_grafana(docker_services):
     """
     docker_services.start("grafana")
     public_port = docker_services.wait_for_service("grafana", 3000)
-    url = "http://{docker_services.docker_ip}:{public_port}".format(**locals())
+    url = "http://admin:admin@{docker_services.docker_ip}:{public_port}".format(**locals())
     return url
 
 


### PR DESCRIPTION
## About

At https://github.com/panodata/grafana-client/pull/110, @bhks added a few more API wrapper functions for Grafana. Thanks! This patch wraps them once more into the command line interface of grafana-wtf.

## Synopsis
```
# Explore plugins.
grafana-wtf plugins list
grafana-wtf plugins status
```
