### PR TITLE
Fix flaky test case `test_log_filter_sql`

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -338,11 +338,13 @@ def test_log_filter_sql(ldi_resources, capsys, caplog):
         grafana_wtf.commands.run()
     captured = capsys.readouterr()
 
-    assert captured.out.strip().split("\n") == [
-        "- url: http://localhost:33333/d/ioUrPwQiz/luftdaten-info-generic-trend-v27",
-        "- url: http://localhost:33333/d/jpVsQxRja/luftdaten-info-generic-trend-v33",
-        "- url: http://localhost:33333/dashboards/f/testdrive/testdrive",
-    ]
+    assert set(captured.out.strip().split("\n")) == set(
+        [
+            "- url: http://localhost:33333/d/ioUrPwQiz/luftdaten-info-generic-trend-v27",
+            "- url: http://localhost:33333/d/jpVsQxRja/luftdaten-info-generic-trend-v33",
+            "- url: http://localhost:33333/dashboards/f/testdrive/testdrive",
+        ]
+    )
 
 
 def test_explore_datasources_used(create_datasource, create_dashboard, capsys, caplog):


### PR DESCRIPTION
## Problem
```
FAILED tests/test_commands.py::test_log_filter_sql
```

-- https://github.com/panodata/grafana-wtf/actions/runs/6767493651/job/18390219379#step:5:246


## References
- Blocks GH-107
