### PR TITLE
Fix datasource output text

### DIFF
--- a/grafana_wtf/report/textual.py
+++ b/grafana_wtf/report/textual.py
@@ -42,7 +42,7 @@ class TextualSearchReport:
 
             # Output match title / entity name.
             name = self.get_item_name(item)
-            section = f"Dashboard »{name}«"
+            section = f"{_s(label)[:-1]} »{name}«"
             print(_ssb(section))
             print("=" * len(section))
 


### PR DESCRIPTION
 I noticed that there is a bug in the textual output as data sources get a prefix of `Dashboard` instead of `Data Source`, because `Dashboard` is hard-coded.

https://github.com/panodata/grafana-wtf/pull/106 can be closed without merging.