### PR TITLE
Fix tests by downgrading to grafanalib==0.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ extras = {
     "test": [
         "pytest<8",
         "lovely-pytest-docker<1",
-        "grafanalib<0.8",
+        "grafanalib==0.7.0",
     ]
 }
 


### PR DESCRIPTION
grafanalib 0.7.1 and newer no longer supports Python 3.7.