### PR TITLE
SQLite cache: Use `requests_cache.CachedSession` for better concurrency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ in progress
 - Add subcommand ``explore permissions``. Thanks, @meyerder.
 - Added support for Python 3.12
 - Removed support for Python 3.7
+- SQLite cache: Use ``requests_cache.CachedSession`` for better concurrency
+  behaviour. Thanks, @JensRichnow and @JWCook.
 
 2024-03-07 0.18.0
 =================

--- a/grafana_wtf/__init__.py
+++ b/grafana_wtf/__init__.py
@@ -2,3 +2,6 @@
 
 __appname__ = "grafana-wtf"
 __version__ = "0.18.0"
+
+# Amalgamate `requests` to `niquests`.
+import grafana_wtf.compat

--- a/grafana_wtf/compat.py
+++ b/grafana_wtf/compat.py
@@ -1,0 +1,12 @@
+from sys import modules
+
+import niquests
+import urllib3
+
+# Amalgamate the module namespace to make all modules aiming
+# to use `requests`, in fact use `niquests` instead.
+modules["requests"] = niquests
+modules["requests.adapters"] = niquests.adapters
+modules["requests.sessions"] = niquests.sessions
+modules["requests.exceptions"] = niquests.exceptions
+modules["requests.packages.urllib3"] = urllib3


### PR DESCRIPTION
## About

- @JensRichnow recently reported problems with concurrency on fast / highly concurrent machines, like the Apple M2 Max.

  - GH-111

- @JWCook suggested to use `requests_cache.CachedSession` to improve the situation.

  - https://github.com/requests-cache/requests-cache/issues/870#issuecomment-1716370826
  - https://github.com/panodata/grafana-wtf/issues/111#issuecomment-1837550141

- This patch aims to do just that. Thank you very much!


## Details

Users on Apple M2 Max reported DB lock errors:

```log
[grafana_wtf.core]
  INFO: Fetching dashboards in parallel with 5 concurrent requests

[requests_cache.backends.sqlite]
  WARNING: Database is locked in thread 6272069632; retrying (1/3)
```

Also segmentation faults, and leaks:

```log
  UserWarning: resource_tracker: There appear to be 1 leaked semaphore
  objects to clean up at shutdown
```

NB: @Ousret, @JWCook: Just in case you didn't know yet -- Apparently, using [Niquests](https://niquests.readthedocs.io/) together with [Requests-Cache](https://requests-cache.readthedocs.io/) works well, at least according to the succeeding test suite.
