### PR TITLE
Improve error reporting on invalid Grafana URLs, or invalid endpoints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ in progress
 - Removed support for Python 3.7
 - SQLite cache: Use ``requests_cache.CachedSession`` for better concurrency
   behaviour. Thanks, @JensRichnow and @JWCook.
+- Improve error reporting and exit behavior when connecting to Grafana
+  instance fails. Thanks, @interfan7.
 
 2024-03-07 0.18.0
 =================

--- a/grafana_wtf/commands.py
+++ b/grafana_wtf/commands.py
@@ -228,12 +228,15 @@ def run():
             'No Grafana URL given. Please use "--grafana-url" option or environment variable "GRAFANA_URL".'
         )
 
-    log.info(f"Using Grafana at {grafana_url}")
+    log.info(f"Grafana location: {grafana_url}")
 
     engine = GrafanaWtf(grafana_url, grafana_token)
+
     engine.enable_cache(expire_after=cache_ttl, drop_cache=options["drop-cache"])
     engine.enable_concurrency(int(options["concurrency"]))
     engine.setup()
+
+    log.info(f"Grafana version: {engine.version}")
 
     if options.replace:
         engine.clear_cache()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,7 +321,7 @@ def grafana_version(docker_grafana):
     """
     engine = GrafanaWtf(grafana_url=docker_grafana, grafana_token=None)
     engine.setup()
-    grafana_version = engine.version()
+    grafana_version = engine.version
     return grafana_version
 
 


### PR DESCRIPTION
## About

Improve robustness when connecting, based on reports by @interfan7 at GH-113. 🙇 

- Rework "health" method (now a property) to raise exception on errors
- Report Grafana version on startup
- Improve error messages
- Add software tests evaluating connectivity error handling