### PR TITLE
SQLite cache: Use SQLite write-ahead logging for better concurrency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ grafana-wtf changelog
 
 in progress
 ===========
+- SQLite cache: Use `SQLite write-ahead logging`_ for better concurrency
+  behaviour, allowing read operations to not block writes. Thanks, @JWCook.
+
+.. _SQLite write-ahead logging: https://sqlite.org/wal.html
 
 2024-03-31 0.19.0
 =================

--- a/grafana_wtf/core.py
+++ b/grafana_wtf/core.py
@@ -72,7 +72,7 @@ class GrafanaEngine:
             log.info(f"Response cache will expire after {expire_after} seconds")
 
         session = CachedSession(
-            cache_name=__appname__, expire_after=expire_after, use_cache_dir=True, **self.session_args
+            cache_name=__appname__, expire_after=expire_after, use_cache_dir=True, wal=True, **self.session_args
         )
         self.set_session(session)
         self.set_user_agent()


### PR DESCRIPTION
## Problem
@edgarasg reported there is still a problem with the SQLite-based cache and concurrent access.

- https://github.com/panodata/grafana-wtf/issues/111#issuecomment-2058840165

## Solution
@JWCook informed us about the `wal=True` argument to requests-cache' Session class/mixin, effectively enabling [SQLite write-ahead logging](https://sqlite.org/wal.html), allowing read operations to not block writes.

- https://github.com/panodata/grafana-wtf/issues/111#issuecomment-2067705159

[1] https://sqlite.org/wal.html